### PR TITLE
Refactor date parser

### DIFF
--- a/rtsl_util/CommonUtils/Dhis2CucumberTestTool/src/main/java/org/rtsl/dhis2/cucumber/Period.java
+++ b/rtsl_util/CommonUtils/Dhis2CucumberTestTool/src/main/java/org/rtsl/dhis2/cucumber/Period.java
@@ -2,145 +2,101 @@ package org.rtsl.dhis2.cucumber;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.Month;
-import java.time.YearMonth;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.temporal.ChronoField;
 import java.time.temporal.IsoFields;
-import java.util.ArrayList;
+import java.time.temporal.TemporalAdjusters;
 
 public class Period {
 
-    private static LocalDateTime now = LocalDateTime.now();
-    private static LocalDate today = LocalDate.now();
-    final static DateTimeFormatter YEAR_MONTH_FORMATTER = DateTimeFormatter.ofPattern("yyyyMM");
-    final static DateTimeFormatter YEAR_QUARTER_FORMATTER = new DateTimeFormatterBuilder().appendValue(ChronoField.YEAR).appendLiteral('Q').appendValue(IsoFields.QUARTER_OF_YEAR).toFormatter();
-
-    public static LocalDate getToday() {
-        return today;
-    }
-
-    public static LocalDateTime getNow() {
-        return now;
-    }
-
-    public void setToday(LocalDate today) {
-        Period.today = today;
-        Period.now = Period.today.atStartOfDay();
-    }
-
-    public static void setToday(CharSequence today) {
-        Period.today = LocalDate.parse(today);
-        Period.now = Period.today.atStartOfDay();
-    }
-
-    public void setNow(LocalDateTime now) {
-        Period.now = now;
-        today = Period.now.toLocalDate();
-    }
-
-    public void setNow(CharSequence now) {
-        Period.now = LocalDateTime.parse(now);
-        today = Period.now.toLocalDate();
-    }
-
-    public static String thisMonth() {
-        return toMonthString(today);
-    }
-
-    public static String lastMonth() {
-        return toMonthString(today.minusMonths(1));
-    }
-    public static ArrayList<String> lastTwelveMonths() {
-        return lastNMonths(12);
-    }
-
-    public static ArrayList<String> lastSixMonths() {
-        return lastNMonths(6);
-    }
-
-    public static ArrayList<String> lastNMonths(int n) {
-        ArrayList<String> months = new ArrayList<>();
-        for (int i = 1; i <= n; i++) {
-            months.add(toMonthString(today.minusMonths(i)));
-        }
-        return months;
-    }
-
-    public static ArrayList<String> monthsThisYear() {
-        int year = today.getYear();
-        ArrayList<String> months = new ArrayList<>();
-        for (Month month : Month.values()) {
-            YearMonth yearMonth = YearMonth.of(year, month);
-            months.add(yearMonth.format(YEAR_MONTH_FORMATTER));
-        }
-        return months;
-    }
-
-    public static String thisQuarter() {
-        return today.format(YEAR_QUARTER_FORMATTER);
-    }
-
-    public static String lastQuarter() {
-        return today.minusMonths(3).format(YEAR_QUARTER_FORMATTER);
-    }
-
-    public static ArrayList<String> lastFourQuarters() {
-        ArrayList<String> quarters = new ArrayList<>();
-        for (int quarter = 1; quarter <= 4; quarter++) {
-            LocalDate date = today.minusMonths(quarter * 3L);
-            quarters.add(today.minusMonths(quarter * 3L).format(YEAR_QUARTER_FORMATTER));
-        }
-        return quarters;
-    }
-
-    public static ArrayList<String> quartersThisYear() {
-        int year = today.getYear();
-        ArrayList<String> quarters = new ArrayList<>();
-        for (int quarter = 1; quarter <= 4; quarter++) {
-            quarters.add(String.format("%dQ%d", year, quarter));
-        }
-        return quarters;
-    }
-
-    public static int thisYear() {
-        return today.getYear();
-    }
-
-    public static int lastYear() {
-        return today.getYear() - 1;
-    }
+    private static final LocalDateTime now = LocalDateTime.now();
+    private static final LocalDate today = LocalDate.now();
+    final static DateTimeFormatter YEAR_MONTH_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+    final static DateTimeFormatter REPORTING_YEAR_MONTH_FORMATTER = DateTimeFormatter.ofPattern("yyyyMM");
+    final static DateTimeFormatter REPORTING_YEAR_QUARTER_FORMATTER = new DateTimeFormatterBuilder().appendValue(ChronoField.YEAR).appendLiteral('Q').appendValue(IsoFields.QUARTER_OF_YEAR).toFormatter();
 
     public static String toDateString(String relativeDate) {
-        return today.minusMonths(numberOfMonthsAgo(relativeDate)).toString();
+        return parseRelativeDate(relativeDate).format(YEAR_MONTH_FORMATTER);
     }
 
-    public static String toMonthString(LocalDate date) {
-        return date.format(YEAR_MONTH_FORMATTER);
+    public static String toReportingDateString(String relativeDate, String periodType) {
+        if (periodType.equalsIgnoreCase("Months"))
+            return parseRelativeDate(relativeDate).format(REPORTING_YEAR_MONTH_FORMATTER);
+        else
+            return parseRelativeDate(relativeDate).format(REPORTING_YEAR_QUARTER_FORMATTER);
     }
 
-    public static String toMonthString(String relativeDate) {
-        return LocalDate.parse(toDateString(relativeDate)).format(YEAR_MONTH_FORMATTER);
+    public static LocalDate toDate(String relativeDate) {
+        return parseRelativeDate(relativeDate);
     }
 
-    public static String toQuarterString(LocalDate date) {
-        return date.format(YEAR_QUARTER_FORMATTER);
-    }
+    public static LocalDate parseRelativeDate(String relativeDate) {
+        // Split the relative date string by "_"
+        String[] parts = relativeDate.split("_");
 
-    public static String toQuarterString(String relativeDate) {
-       return today.minusMonths(numberOfMonthsAgo(relativeDate)).format(YEAR_QUARTER_FORMATTER);
-    }
+        // Initialize the finalDate as the current date
+        LocalDate finalDate = today;
 
-    private static Integer numberOfMonthsAgo(String relativeDate) {
-        if (relativeDate.equals("thisMonth") || relativeDate.equals("thisQuarter"))
-            return 0;
-        else {
-            String[] relativeDateArray = relativeDate.split("_");
-            if (relativeDateArray[1].equals("MonthsAgo") || relativeDateArray[1].equals("MonthAgo"))
-                return Integer.parseInt(relativeDateArray[0]);
-            else
-                return 3 * Integer.parseInt(relativeDateArray[0]);
+        // Loop through the parts and apply the changes to the date
+        for (int i = 0; i < parts.length; i++) {
+            switch (parts[i]) {
+                case "thisQuarter":
+                    // Calculate the start of the current quarter
+                    finalDate = today.with(IsoFields.DAY_OF_QUARTER, 1L);
+                    break;
+                case "thisMonth":
+                    // Calculate the start of the current month
+                    finalDate = today.withDayOfMonth(1);
+                    break;
+                case "BeginningOfMonth":
+                    // Set to the beginning of the current month
+                    finalDate = finalDate.withDayOfMonth(1);
+                    break;
+                case "EndOfMonth":
+                    // Set to the end of the month
+                    finalDate = finalDate.with(TemporalAdjusters.lastDayOfMonth());
+                    break;
+                case "MonthsAgo", "MonthAgo":
+                    // Get the number before "MonthsAgo" and adjust the date
+                    int monthsAgo = Integer.parseInt(parts[i - 1]);
+                    finalDate = finalDate.minusMonths(monthsAgo).withDayOfMonth(1);
+                    break;
+                case "QuartersAgo", "QuarterAgo":
+                    // Get the number before "QuartersAgo" and adjust the date
+                    int quartersAgo = Integer.parseInt(parts[i - 1]);
+                    finalDate = finalDate.with(IsoFields.DAY_OF_QUARTER, 1L).minusMonths(quartersAgo * 3L);
+                    break;
+                case "DaysAgo":
+                    // Get the number before "DaysAgo" and adjust the date
+                    int daysAgo = Integer.parseInt(parts[i - 1]);
+                    finalDate = finalDate.minusDays(daysAgo);
+                    break;
+                case "Plus":
+                    // Check for whether to add months or days
+                    if (parts[i + 2].equals("Months") || parts[i + 2].equals("Month")) {
+                        int monthsToAdd = Integer.parseInt(parts[i + 1]);
+                        finalDate = finalDate.plusMonths(monthsToAdd);
+                    } else if (parts[i + 2].equals("Days") || parts[i + 2].equals("Day")) {
+                        int daysToAdd = Integer.parseInt(parts[i + 1]);
+                        finalDate = finalDate.plusDays(daysToAdd);
+                    }
+                    i += 2;
+                    break;
+                case "Minus":
+                    // Handle subtraction for months or days
+                    if (parts[i + 2].equals("Months") || parts[i + 2].equals("Month")) {
+                        int monthsToSubtract = Integer.parseInt(parts[i + 1]);
+                        finalDate = finalDate.minusMonths(monthsToSubtract);
+                    } else if (parts[i + 2].equals("Days") || parts[i + 2].equals("Day")) {
+                        int daysToSubtract = Integer.parseInt(parts[i + 1]);
+                        finalDate = finalDate.minusDays(daysToSubtract);
+                    }
+                    i += 2;
+                    break;
+            }
         }
+
+        return finalDate;
     }
 }

--- a/rtsl_util/CommonUtils/Dhis2CucumberTestTool/src/main/java/org/rtsl/dhis2/cucumber/definitions/Dhis2StepDefinitions.java
+++ b/rtsl_util/CommonUtils/Dhis2CucumberTestTool/src/main/java/org/rtsl/dhis2/cucumber/definitions/Dhis2StepDefinitions.java
@@ -241,7 +241,7 @@ public class Dhis2StepDefinitions {
         String dimensionItemId = getDimensionItemId(dimensionItemType, dimensionItemName);
         Map<String, String> actualPeriodValues = getAnalyticData(dimensionItemId, dimensionItemName, periodType);
         for (String relativePeriod : dataTable.keySet()) {
-            String period = periodType.equalsIgnoreCase("months") ? Period.toMonthString(relativePeriod) :  Period.toQuarterString(relativePeriod);
+            String period = Period.toReportingDateString(relativePeriod, periodType);
             assertEquals(dataTable.get(relativePeriod),
                     actualPeriodValues.get(period),
                     dimensionItemName + ": <" + dimensionItemId + "> for the <" + period + "(" + relativePeriod + ")" + "> in Organisation Unit:<" + this.currentOrgUnitId + ">." +

--- a/rtsl_util/CommonUtils/Dhis2CucumberTestTool/src/test/resources/local_tests/scenarios/hypertension/hypertension_data_audit.feature
+++ b/rtsl_util/CommonUtils/Dhis2CucumberTestTool/src/test/resources/local_tests/scenarios/hypertension/hypertension_data_audit.feature
@@ -438,7 +438,7 @@ Feature: Hypertension Data Audit
     # Patient 1 - Dead
     #
 
-    And I create a new TEI on "2_QuartersAgo" for this Facility with the following attributes
+    And I create a new TEI on "3_QuartersAgo" for this Facility with the following attributes
       | Given name         | Joe          |
       | Family name        | Bloggs       |
       | Sex                | MALE         |
@@ -449,13 +449,13 @@ Feature: Hypertension Data Audit
       | District           | KOLARA       |
       | Data consent       | true         |
       | NCD Patient Status | ACTIVE       |
-    And That TEI has a "Hypertension & Diabetes visit" event on "2_QuartersAgo" with following data
+    And That TEI has a "Hypertension & Diabetes visit" event on "3_QuartersAgo" with following data
       | Systole  | 145 |
       | Diastole | 92  |
-    And That TEI has a "Hypertension & Diabetes visit" event on "1_QuarterAgo" with following data
+    And That TEI has a "Hypertension & Diabetes visit" event on "3_QuarterAgo_Plus_2_Months" with following data
       | Systole  | 140 |
       | Diastole | 87  |
-    And That TEI has a "Hypertension & Diabetes visit" event on "1_QuarterAgo" with following data
+    And That TEI has a "Hypertension & Diabetes visit" event on "2_QuartersAgo_Plus_1_Month" with following data
       | Systole  | 136 |
       | Diastole | 84  |
     And That TEI was updated on "thisQuarter" with the following attributes
@@ -463,7 +463,7 @@ Feature: Hypertension Data Audit
     #
     # Patient 2 - Not a hypertension TEI
     #
-    And I create a new TEI on "1_QuarterAgo" for this Facility with the following attributes
+    And I create a new TEI on "3_QuarterAgo" for this Facility with the following attributes
       | Given name         | Fabian       |
       | Family name        | Moore        |
       | Sex                | MALE         |
@@ -474,13 +474,13 @@ Feature: Hypertension Data Audit
       | District           | KOLARA       |
       | Data consent       | true         |
       | NCD Patient Status | ACTIVE       |
-    And That TEI has a "Hypertension & Diabetes visit" event on "1_QuarterAgo" with following data
+    And That TEI has a "Hypertension & Diabetes visit" event on "3_QuarterAgo" with following data
       | HTN - Type of diabetes measure? | HBA1C |
       | HTN - Blood sugar reading       | 9     |
     #
-    #  Patient 3 - Patient under care, TEI under care registered before the past 3 months and controlled
+    #  Patient 3 - Patient under care, TEI under care registered before the past 3 months and controlled visit in following quarter
     #
-    And I create a new TEI on "3_QuartersAgo" for this Facility with the following attributes
+    And I create a new TEI on "4_QuartersAgo" for this Facility with the following attributes
       | Given name         | Sue          |
       | Family name        | Perkins      |
       | Sex                | MALE         |
@@ -491,28 +491,28 @@ Feature: Hypertension Data Audit
       | District           | KOLARA       |
       | Data consent       | true         |
       | NCD Patient Status | ACTIVE       |
-    And That TEI has a "Hypertension & Diabetes visit" event on "3_QuartersAgo" with following data
+    And That TEI has a "Hypertension & Diabetes visit" event on "4_QuartersAgo" with following data
       | Systole  | 147 |
       | Diastole | 89  |
-    And That TEI has a "Hypertension & Diabetes visit" event on "3_QuartersAgo" with following data
+    And That TEI has a "Hypertension & Diabetes visit" event on "4_QuartersAgo_Plus_1_Month" with following data
       | Systole  | 142 |
       | Diastole | 87  |
-    And That TEI has a "Hypertension & Diabetes visit" event on "2_QuartersAgo" with following data
+    And That TEI has a "Hypertension & Diabetes visit" event on "3_QuartersAgo" with following data
       | Systole  | 140 |
       | Diastole | 83  |
-    And That TEI has a "Hypertension & Diabetes visit" event on "2_QuartersAgo" with following data
+    And That TEI has a "Hypertension & Diabetes visit" event on "3_QuartersAgo_Plus_1_Month" with following data
       | Systole  | 135 |
       | Diastole | 84  |
-    And That TEI has a "Hypertension & Diabetes visit" event on "1_QuarterAgo" with following data
+    And That TEI has a "Hypertension & Diabetes visit" event on "3_QuartersAgo_Plus_2_Month" with following data
       | Systole  | 134 |
       | Diastole | 83  |
-    And That TEI has a "Hypertension & Diabetes visit" event on "1_QuarterAgo" with following data
+    And That TEI has a "Hypertension & Diabetes visit" event on "2_QuartersAgo_Plus_1_Month" with following data
       | Systole  | 137 |
       | Diastole | 86  |
     #
-    #  Patient 4 - Patient under care, TEI under care registered before the past 3 months and controlled
+    #  Patient 4 - Patient under care, TEI under care registered before the past 3 months and uncontrolled visit in following quarter
     #
-    And I create a new TEI on "6_QuartersAgo" for this Facility with the following attributes
+    And I create a new TEI on "3_QuartersAgo" for this Facility with the following attributes
       | Given name         | Kiran        |
       | Family name        | Kishor       |
       | Sex                | MALE         |
@@ -523,25 +523,25 @@ Feature: Hypertension Data Audit
       | District           | KOLARA       |
       | Data consent       | true         |
       | NCD Patient Status | ACTIVE       |
-    And That TEI has a "Hypertension & Diabetes visit" event on "6_QuartersAgo" with following data
+    And That TEI has a "Hypertension & Diabetes visit" event on "3_QuartersAgo" with following data
       | Systole  | 142 |
       | Diastole | 95  |
-    And That TEI has a "Hypertension & Diabetes visit" event on "6_QuartersAgo" with following data
+    And That TEI has a "Hypertension & Diabetes visit" event on "3_QuartersAgo_Plus_1_Month" with following data
       | Systole  | 139 |
       | Diastole | 90  |
-    And That TEI has a "Hypertension & Diabetes visit" event on "6_QuartersAgo" with following data
+    And That TEI has a "Hypertension & Diabetes visit" event on "3_QuartersAgo_Plus_2_Month" with following data
       | Systole  | 132 |
       | Diastole | 82  |
-    And That TEI has a "Hypertension & Diabetes visit" event on "6_QuartersAgo" with following data
+    And That TEI has a "Hypertension & Diabetes visit" event on "2_QuartersAgo" with following data
       | Systole  | 128 |
       | Diastole | 72  |
-    And That TEI has a "Hypertension & Diabetes visit" event on "6_QuarterAgo" with following data
+    And That TEI has a "Hypertension & Diabetes visit" event on "2_QuartersAgo_Plus_1_Month" with following data
       | Systole  | 140 |
       | Diastole | 88  |
     #
-    #  Patient 5 - Patient under care, TEI under care registered before the past 3 months and uncontrolled
+    #  Patient 5 - Patient under care, TEI under care registered before the past 3 months and uncontrolled visit in following quarter
     #
-    And I create a new TEI on "2_QuartersAgo" for this Facility with the following attributes
+    And I create a new TEI on "4_QuartersAgo_Plus_2_Months" for this Facility with the following attributes
       | Given name         | Lilly        |
       | Family name        | Martin       |
       | Sex                | MALE         |
@@ -552,28 +552,28 @@ Feature: Hypertension Data Audit
       | District           | KOLARA       |
       | Data consent       | true         |
       | NCD Patient Status | ACTIVE       |
-    And That TEI has a "Hypertension & Diabetes visit" event on "2_QuartersAgo" with following data
+    And That TEI has a "Hypertension & Diabetes visit" event on "4_QuartersAgo_Plus_2_Months" with following data
       | Systole  | 142 |
       | Diastole | 95  |
-    And That TEI has a "Hypertension & Diabetes visit" event on "2_QuartersAgo" with following data
+    And That TEI has a "Hypertension & Diabetes visit" event on "3_QuartersAgo" with following data
       | Systole  | 132 |
       | Diastole | 82  |
-    And That TEI has a "Hypertension & Diabetes visit" event on "2_QuartersAgo" with following data
+    And That TEI has a "Hypertension & Diabetes visit" event on "3_QuartersAgo_Plus_1_Months" with following data
       | Systole  | 146 |
       | Diastole | 93  |
-    And That TEI has a "Hypertension & Diabetes visit" event on "1_QuarterAgo" with following data
+    And That TEI has a "Hypertension & Diabetes visit" event on "3_QuartersAgo_Plus_2_Months" with following data
       | Systole  | 143 |
       | Diastole | 89  |
-    And That TEI has a "Hypertension & Diabetes visit" event on "1_QuarterAgo" with following data
+    And That TEI has a "Hypertension & Diabetes visit" event on "2_QuartersAgo_Plus_1_Month" with following data
       | Systole  | 138 |
       | Diastole | 87  |
-    And That TEI has a "Hypertension & Diabetes visit" event on "thisQuarter" with following data
+    And That TEI has a "Hypertension & Diabetes visit" event on "2_QuartersAgo_Plus_2_Months" with following data
       | Systole  | 140 |
       | Diastole | 91  |
   #
-  #  Patient 6 - Patient under care, TEI under care registered before the past 3 months and no visit in last 3 months
+  #  Patient 6 - Patient under care, TEI under care registered before the past 3 months and uncontrolled visit in following quarter
   #
-    And I create a new TEI on "thisQuarter" for this Facility with the following attributes
+    And I create a new TEI on "5_QuartersAgo" for this Facility with the following attributes
       | Given name         | Ajesh        |
       | Family name        | Choudhary    |
       | Sex                | MALE         |
@@ -584,28 +584,28 @@ Feature: Hypertension Data Audit
       | District           | KOLARA       |
       | Data consent       | true         |
       | NCD Patient Status | ACTIVE       |
-    And That TEI has a "Hypertension & Diabetes visit" event on "4_QuartersAgo" with following data
+    And That TEI has a "Hypertension & Diabetes visit" event on "5_QuartersAgo" with following data
       | Systole  | 146 |
       | Diastole | 93  |
-    And That TEI has a "Hypertension & Diabetes visit" event on "3_QuartersAgo" with following data
+    And That TEI has a "Hypertension & Diabetes visit" event on "5_QuartersAgo_Plus_1_Month" with following data
       | Systole  | 143 |
       | Diastole | 93  |
-    And That TEI has a "Hypertension & Diabetes visit" event on "3_QuartersAgo" with following data
+    And That TEI has a "Hypertension & Diabetes visit" event on "4_QuartersAgo" with following data
       | Systole  | 138 |
       | Diastole | 83  |
-    And That TEI has a "Hypertension & Diabetes visit" event on "3_QuartersAgo" with following data
+    And That TEI has a "Hypertension & Diabetes visit" event on "4_QuartersAgo_Plus_1_Month" with following data
       | Systole  | 143 |
       | Diastole | 91  |
-    And That TEI has a "Hypertension & Diabetes visit" event on "2_QuartersAgo" with following data
+    And That TEI has a "Hypertension & Diabetes visit" event on "3_QuartersAgo" with following data
       | Systole  | 148 |
       | Diastole | 93  |
-    And That TEI has a "Hypertension & Diabetes visit" event on "2_QuartersAgo" with following data
+    And That TEI has a "Hypertension & Diabetes visit" event on "3_QuartersAgo_Plus_1_Month" with following data
       | Systole  | 136 |
       | Diastole | 82  |
   #
-  #  Patient 7 - Patient under care, TEI under care registered before the past 3 months and controlled
+  #  Patient 7 - Patient under care, TEI under care registered before the past 3 months and no visit in following quarter
   #
-    And I create a new TEI on "1_QuartersAgo" for this Facility with the following attributes
+    And I create a new TEI on "3_QuartersAgo" for this Facility with the following attributes
       | Given name         | Bianca       |
       | Family name        | Santos       |
       | Sex                | MALE         |
@@ -616,19 +616,19 @@ Feature: Hypertension Data Audit
       | District           | KOLARA       |
       | Data consent       | true         |
       | NCD Patient Status | ACTIVE       |
-    And That TEI has a "Hypertension & Diabetes visit" event on "1_QuartersAgo" with following data
+    And That TEI has a "Hypertension & Diabetes visit" event on "3_QuartersAgo" with following data
       | Systole  | 141 |
       | Diastole | 94  |
-    And That TEI has a "Hypertension & Diabetes visit" event on "1_QuarterAgo" with following data
+    And That TEI has a "Hypertension & Diabetes visit" event on "3_QuarterAgo_Plus_1_Month" with following data
       | Systole  | 143 |
       | Diastole | 93  |
-    And That TEI has a "Hypertension & Diabetes visit" event on "thisQuarter" with following data
+    And That TEI has a "Hypertension & Diabetes visit" event on "3_QuarterAgo_Plus_2_Month" with following data
       | Systole  | 138 |
       | Diastole | 83  |
   #
-  #  Patient 8 - Patient has not visited for more than 12 months
+  #  Patient 8 - Patient who has no visit in following quarter
   #
-    And I create a new TEI on "12_QuartersAgo" for this Facility with the following attributes
+    And I create a new TEI on "2_QuartersAgo" for this Facility with the following attributes
       | Given name         | Joanne       |
       | Family name        | Holme        |
       | Sex                | MALE         |
@@ -639,11 +639,11 @@ Feature: Hypertension Data Audit
       | District           | KOLARA       |
       | Data consent       | true         |
       | NCD Patient Status | ACTIVE       |
-    And That TEI has a "Hypertension & Diabetes visit" event on "6_QuartersAgo" with following data
+    And That TEI has a "Hypertension & Diabetes visit" event on "2_QuartersAgo" with following data
       | Systole  | 152 |
       | Diastole | 98  |
   #
-  #  Patient 9 - Patient under care, TEI under care registered before the past 3 months and controlled
+  #  Patient 9 - Patient under care, TEI under care registered before the past 3 months and controlled visit in following quarter
   #
     And I create a new TEI on "2_QuartersAgo" for this Facility with the following attributes
       | Given name         | Karlo        |
@@ -662,19 +662,19 @@ Feature: Hypertension Data Audit
     And That TEI has a "Hypertension & Diabetes visit" event on "1_QuarterAgo" with following data
       | Systole  | 145 |
       | Diastole | 98  |
-    And That TEI has a "Hypertension & Diabetes visit" event on "1_QuartersAgo" with following data
+    And That TEI has a "Hypertension & Diabetes visit" event on "1_QuartersAgo_Plus_1_Month" with following data
       | Systole  | 138 |
       | Diastole | 91  |
-    And That TEI has a "Hypertension & Diabetes visit" event on "1_QuarterAgo" with following data
+    And That TEI has a "Hypertension & Diabetes visit" event on "1_QuarterAgo_Plus_2_Month" with following data
       | Systole  | 128 |
       | Diastole | 76  |
     And That TEI has a "Hypertension & Diabetes visit" event on "thisQuarter" with following data
       | Systole  | 125 |
       | Diastole | 77  |
   #
-  #  Patient 10 - Patient under care, TEI under care registered before the past 3 months and controlled
+  #  Patient 10 - Patient under care, TEI under care registered before the past 3 months and controlled visit in following quarter
   #
-    And I create a new TEI on "2_QuartersAgo" for this Facility with the following attributes
+    And I create a new TEI on "3_QuartersAgo" for this Facility with the following attributes
       | Given name         | Adrien       |
       | Family name        | Palomo       |
       | Sex                | MALE         |
@@ -685,17 +685,17 @@ Feature: Hypertension Data Audit
       | District           | KOLARA       |
       | Data consent       | true         |
       | NCD Patient Status | ACTIVE       |
-    And That TEI has a "Hypertension & Diabetes visit" event on "2_QuartersAgo" with following data
+    And That TEI has a "Hypertension & Diabetes visit" event on "3_QuartersAgo" with following data
       | Systole  | 152 |
       | Diastole | 98  |
-    And That TEI has a "Hypertension & Diabetes visit" event on "2_QuartersAgo" with following data
+    And That TEI has a "Hypertension & Diabetes visit" event on "3_QuartersAgo_Plus_1_Month" with following data
       | Systole  | 143 |
       | Diastole | 93  |
-    And That TEI has a "Hypertension & Diabetes visit" event on "1_QuarterAgo" with following data
+    And That TEI has a "Hypertension & Diabetes visit" event on "2_QuarterAgo" with following data
       | Systole  | 138 |
       | Diastole | 83  |
   #
-  #  Patient 11 -  Patient under care, TEI under care registered before the past 3 months and no visit
+  #  Patient 11 -  Patient under care, TEI under care registered before the past 3 months and controlled visit in following quarter
   #
     And I create a new TEI on "3_QuartersAgo" for this Facility with the following attributes
       | Given name         | Iverna       |
@@ -714,13 +714,13 @@ Feature: Hypertension Data Audit
     And That TEI has a "Hypertension & Diabetes visit" event on "2_QuartersAgo" with following data
       | Systole  | 143 |
       | Diastole | 93  |
-    And That TEI has a "Hypertension & Diabetes visit" event on "2_QuartersAgo" with following data
+    And That TEI has a "Hypertension & Diabetes visit" event on "2_QuartersAgo_Plus_1_Month" with following data
       | Systole  | 138 |
       | Diastole | 83  |
     And That TEI has a "Hypertension & Diabetes visit" event on "1_QuarterAgo" with following data
       | Systole  | 137 |
       | Diastole | 87  |
-    And That TEI has a "Hypertension & Diabetes visit" event on "1_QuarterAgo" with following data
+    And That TEI has a "Hypertension & Diabetes visit" event on "1_QuarterAgo_Plus_1_Month" with following data
       | Systole  | 135 |
       | Diastole | 87  |
     And That TEI has a "Hypertension & Diabetes visit" event on "thisQuarter" with following data
@@ -729,38 +729,38 @@ Feature: Hypertension Data Audit
       | HTN - Type of diabetes measure? | FBS      |
       | HTN - Blood sugar reading       | 200      |
       | HTN - Blood sugar unit          | MG_OR_DL |
-    And That TEI has a "Hypertension & Diabetes visit" event on "thisQuarter" with following data
+    And That TEI has a "Hypertension & Diabetes visit" event on "thisQuarter_Plus_1_Month" with following data
       | HTN - Type of diabetes measure? | FBS      |
       | HTN - Blood sugar reading       | 130      |
       | HTN - Blood sugar unit          | MG_OR_DL |
-    And That TEI has a "Hypertension & Diabetes visit" event on "thisQuarter" with following data
+    And That TEI has a "Hypertension & Diabetes visit" event on "thisQuarter_Plus_1_Month_15_Days" with following data
       | HTN - Type of diabetes measure? | FBS      |
       | HTN - Blood sugar reading       | 100      |
       | HTN - Blood sugar unit          | MG_OR_DL |
 
     When I export the analytics
-    
-    Then The value of "PI":"HTN - Patients with controlled BP at latest visit in this quarter" with period type "Quarters" should be
-      | 4_QuartersAgo | 0 |
-      | 3_QuartersAgo | 0 |
-      | 2_QuartersAgo | 3 |
-      | 1_QuarterAgo  | 1 |
-      | thisQuarter   | 0 |
+
     Then The value of "PI":"HTN - Total patient registrations in previous quarter" with period type "Quarters" should be
       | 4_QuartersAgo | 1 |
-      | 3_QuartersAgo | 1 |
+      | 3_QuartersAgo | 2 |
       | 2_QuartersAgo | 4 |
-      | 1_QuarterAgo  | 1 |
-      | thisQuarter   | 1 |
-    Then The value of "PI":"HTN - Patients with no visit in this quarter" with period type "Quarters" should be
-      | 4_QuartersAgo | 1 |
-      | 3_QuartersAgo | 1 |
-      | 2_QuartersAgo | 0 |
-      | 1_QuarterAgo  | 0 |
-      | thisQuarter   | 1 |
-    Then The value of "PI":"HTN - Patients with uncontrolled BP from latest visit in this quarter" with period type "Quarters" should be
+      | 1_QuarterAgo  | 2 |
+      | thisQuarter   | 0 |
+    Then The value of "PI":"HTN - Patients with controlled BP at latest visit in this quarter" with period type "Quarters" should be
       | 4_QuartersAgo | 0 |
+      | 3_QuartersAgo | 1 |
+      | 2_QuartersAgo | 2 |
+      | 1_QuarterAgo  | 1 |
+      | thisQuarter   | 0 |
+    Then The value of "PI":"HTN - Patients with uncontrolled BP from latest visit in this quarter" with period type "Quarters" should be
+      | 4_QuartersAgo | 1 |
       | 3_QuartersAgo | 1 |
       | 2_QuartersAgo | 1 |
       | 1_QuarterAgo  | 0 |
+      | thisQuarter   | 0 |
+    Then The value of "PI":"HTN - Patients with no visit in this quarter" with period type "Quarters" should be
+      | 4_QuartersAgo | 0 |
+      | 3_QuartersAgo | 0 |
+      | 2_QuartersAgo | 1 |
+      | 1_QuarterAgo  | 1 |
       | thisQuarter   | 0 |

--- a/rtsl_util/CommonUtils/Dhis2CucumberTestTool/src/test/resources/local_tests/scenarios/hypertension/hypertension_overdue_patients.feature
+++ b/rtsl_util/CommonUtils/Dhis2CucumberTestTool/src/test/resources/local_tests/scenarios/hypertension/hypertension_overdue_patients.feature
@@ -151,11 +151,10 @@ Feature: Number of overdue patients
     And That TEI has a "Hypertension & Diabetes visit" event on "7_MonthsAgo" with following data
       | Systole  | 142 |
       | Diastole | 95  |
-    And That TEI has a "Calling report" event on "5_MonthsAgo" with following data
+    And That TEI has a "Calling report" event on "5_MonthsAgo_Plus_1_Day" with following data
       | Result of call                          | REMOVE_FROM_OVERDUE |
       | HTN - Remove from overdue list because: | OTHER               |
-    And That TEI has a "Hypertension & Diabetes visit" event scheduled for "5_MonthsAgo"
-    And That TEI has a "Hypertension & Diabetes visit" event on "3_MonthsAgo" with following data
+    And That TEI has a "Hypertension & Diabetes visit" event on "3_MonthsAgo" which was scheduled on "5_MonthsAgo" with following data
       | Systole  | 142 |
       | Diastole | 95  |
 


### PR DESCRIPTION
## Because

Framework could only parse "x_Month[s]Ago", "this_Month", "x_Quarter[s]Ago", "this_Quarter".

## This Address

- Extend the relative date parsing to support the following relative dates:
  -  "x_Month[s]Ago_Plus_x_Month[s]"
  -  "x_Month[s]Ago_Minus_x_Month[s]"
  -  "x_Month[s]Ago_Plus_x_Day[s]"
  -  "x_Month[s]Ago_Minus_x_Day[s]"
  - "this_Month_Plus_x_Month[s]"
  - "this_Month_Minus_x_Month[s]"
  - "this_Month_Plus_x_Day[s]"
  - "this_Month_Minus_x_Day[s]"
  - "x_Quarter[s]Ago_Plus_x_Month[s]"
  - "x_Quarter[s]Ago_Minus_x_Month[s]"
  - "x_Quarter[s]Ago_Plus_x_Day[s]"
  - "x_Quarter[s]Ago_Minus_x_Day[s]"
  - "this_Quarter_Plus_x_Month[s]"
  - "this_Quarter_Minus_x_Month[s]"
  - "this_Quarter_Plus_x_Day[s]"
  - "this_Quarter_Minus_x_Day[s]"
- Updated the feature files with the newly supported relative dates