### PR TITLE
Fix  test for overdue indicators

### DIFF
--- a/rtsl_util/CommonUtils/Dhis2CucumberTestTool/src/main/java/org/rtsl/dhis2/cucumber/Dhis2IdConverter.java
+++ b/rtsl_util/CommonUtils/Dhis2CucumberTestTool/src/main/java/org/rtsl/dhis2/cucumber/Dhis2IdConverter.java
@@ -23,7 +23,7 @@ public final class Dhis2IdConverter {
 
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final Dhis2HttpClient dhis2HttpClient;
-    // TODO Might cause type conflicts if two object of different type share the name, shortName
+    // TODO Refactor the code. We probably do not need all these maps.
     private final Map<String, String> trackedEntityAttributeIdFromShortName = new HashMap<>();
     private final Map<String, String> trackedEntityAttributeIdFromName = new HashMap<>();
     private final Map<String, String> trackedEntityAttributeIdFromId = new HashMap<>();

--- a/rtsl_util/CommonUtils/Dhis2CucumberTestTool/src/main/java/org/rtsl/dhis2/cucumber/definitions/Dhis2StepDefinitions.java
+++ b/rtsl_util/CommonUtils/Dhis2CucumberTestTool/src/main/java/org/rtsl/dhis2/cucumber/definitions/Dhis2StepDefinitions.java
@@ -194,8 +194,8 @@ public class Dhis2StepDefinitions {
         String response;
         String lastExecutedStatus;
 
-        // Wait 1 sec for the trigger logic to complete
-        Thread.sleep(1000);
+        // Wait until the trigger logic completes
+        waitUntilDBTriggerCompletion();
 
         executeJob(exportAnalyticsJobId);
         do {
@@ -293,6 +293,20 @@ public class Dhis2StepDefinitions {
         scenario.log("Signed in as a Superuser user with access to update the metadata");
     }
 
+    @Given("Clears cache")
+    public void clearsCache() throws Exception {
+        String endpoint = "api/maintenance?cacheClear=true&appReload=true";
+        String response = dhis2HttpClient.doPost(endpoint);
+        LOGGER.info("Response {}", response);
+        scenario.log("Cleared cache");
+    }
+
+//    TODO Rewrite the function to estimate the trigger completion time.
+//    Currently we wait for 1 second before we run analytics.
+    private void waitUntilDBTriggerCompletion() throws Exception{
+        Thread.sleep(1000);
+    }
+
     private List<AttributeInfo> getAttributes(Map<String, String> data) {
         List<AttributeInfo> returnList = new ArrayList<>();
         for (String currentKey : data.keySet()) {
@@ -341,13 +355,5 @@ public class Dhis2StepDefinitions {
         LOGGER.info("Response {}", response);
         scenario.log(dimensionItemName + ": " + dimensionItemId + " for the `" + periods + "` in Organisation Unit:" + orgUnit + " is " + actualPeriodValues);
         return actualPeriodValues;
-    }
-
-    @Given("Clears cache")
-    public void clearsCache() throws Exception {
-        String endpoint = "api/maintenance?cacheClear=true&appReload=true";
-        String response = dhis2HttpClient.doPost(endpoint);
-        LOGGER.info("Response {}", response);
-        scenario.log("Cleared cache");
     }
 }

--- a/rtsl_util/CommonUtils/Dhis2CucumberTestTool/src/main/java/org/rtsl/dhis2/cucumber/definitions/Dhis2StepDefinitions.java
+++ b/rtsl_util/CommonUtils/Dhis2CucumberTestTool/src/main/java/org/rtsl/dhis2/cucumber/definitions/Dhis2StepDefinitions.java
@@ -194,6 +194,9 @@ public class Dhis2StepDefinitions {
         String response;
         String lastExecutedStatus;
 
+        // Wait 1 sec for the trigger logic to complete
+        Thread.sleep(1000);
+
         executeJob(exportAnalyticsJobId);
         do {
             // Loop until job is finished

--- a/rtsl_util/CommonUtils/Dhis2CucumberTestTool/src/test/resources/local_tests/scenarios/hypertension/hypertension_overdue_patients.feature
+++ b/rtsl_util/CommonUtils/Dhis2CucumberTestTool/src/test/resources/local_tests/scenarios/hypertension/hypertension_overdue_patients.feature
@@ -52,7 +52,7 @@ Feature: Number of overdue patients
       | 3_MonthsAgo  | 1 |
       | 4_MonthsAgo  | 1 |
       | 5_MonthsAgo  | 1 |
-      | 6_MonthsAgo  | 1 |
+      | 6_MonthsAgo  | 0 |
       | 7_MonthsAgo  | 0 |
       | 8_MonthsAgo  | 0 |
       | 9_MonthsAgo  | 0 |
@@ -108,7 +108,7 @@ Feature: Number of overdue patients
       | 3_MonthsAgo  | 1 |
       | 4_MonthsAgo  | 1 |
       | 5_MonthsAgo  | 1 |
-      | 6_MonthsAgo  | 1 |
+      | 6_MonthsAgo  | 0 |
       | 7_MonthsAgo  | 0 |
       | 8_MonthsAgo  | 0 |
       | 9_MonthsAgo  | 0 |

--- a/rtsl_util/CommonUtils/Dhis2CucumberTestTool/src/test/resources/local_tests/scenarios/hypertension/hypertension_overdue_patients.feature
+++ b/rtsl_util/CommonUtils/Dhis2CucumberTestTool/src/test/resources/local_tests/scenarios/hypertension/hypertension_overdue_patients.feature
@@ -135,7 +135,7 @@ Feature: Number of overdue patients
     And That TEI has a "Hypertension & Diabetes visit" event on "7_MonthsAgo" with following data
       | Systole  | 142 |
       | Diastole | 95  |
-    And That TEI has a "Hypertension & Diabetes visit" event scheduled for "6_MonthsAgo"
+    And That TEI has a "Hypertension & Diabetes visit" event scheduled for "6_MonthsAgo_Minus_1_Day"
 
     And I create a new TEI on "7_MonthsAgo" for this Facility with the following attributes
       | GEN - Given name                      | Angel        |
@@ -164,9 +164,9 @@ Feature: Number of overdue patients
       | thisMonth    | 1 |
       | 1_MonthAgo   | 1 |
       | 2_MonthsAgo  | 1 |
-      | 3_MonthsAgo  | 1 |
+      | 3_MonthsAgo  | 2 |
       | 4_MonthsAgo  | 2 |
-      | 5_MonthsAgo  | 2 |
+      | 5_MonthsAgo  | 1 |
       | 6_MonthsAgo  | 1 |
       | 7_MonthsAgo  | 0 |
       | 8_MonthsAgo  | 0 |

--- a/rtsl_util/CommonUtils/Dhis2CucumberTestTool/src/test/resources/local_tests/scenarios/hypertension/hypertension_patient_under_care_controlled.feature
+++ b/rtsl_util/CommonUtils/Dhis2CucumberTestTool/src/test/resources/local_tests/scenarios/hypertension/hypertension_patient_under_care_controlled.feature
@@ -11,7 +11,6 @@
   And I assign the current user to the current orgUnit
   And I register that Facility for program "Hypertension & Diabetes"
   And I create a new TEI on "7_MonthsAgo" for this Facility with the following attributes
-  Given I create a new TEI on "7_MonthsAgo" for this Facility with the following attributes
    | GEN - Given name                      | Priyanka     |
    | GEN - Family name                     | Chopra       |
    | GEN - Sex                             | MALE         |

--- a/rtsl_util/CommonUtils/Dhis2CucumberTestTool/src/test/resources/local_tests/scenarios/hypertension/hypertension_patient_under_registered_before_past_3_months.feature
+++ b/rtsl_util/CommonUtils/Dhis2CucumberTestTool/src/test/resources/local_tests/scenarios/hypertension/hypertension_patient_under_registered_before_past_3_months.feature
@@ -351,9 +351,9 @@ Feature: Audit the program indicator: HTN - Patients under care registered befor
       | 4_MonthsAgo  | 2 |
       | 5_MonthsAgo  | 1 |
       | 6_MonthsAgo  | 1 |
-      | 7_MonthsAgo  | 1 |
-      | 8_MonthsAgo  | 0 |
-      | 9_MonthsAgo  | 0 |
-      | 10_MonthsAgo | 0 |
-      | 11_MonthsAgo | 0 |
-      | 12_MonthsAgo | 0 |
+      | 7_MonthsAgo  | 2 |
+      | 8_MonthsAgo  | 1 |
+      | 9_MonthsAgo  | 1 |
+      | 10_MonthsAgo | 1 |
+      | 11_MonthsAgo | 1 |
+      | 12_MonthsAgo | 1 |


### PR DESCRIPTION
## Because
- The tests for overdue patient indicator fails.
- Last event in a test case is not exported to analytic table.

## This addresses
- The trigger code underneath takes almost 2ms to 1s to run the logic before it saves the row on to the DB. Some rows might not get exported to analytic table if the export begins before the completion. Until we find a way to dynamically know the time when a row actually get saved on to the DB, we can allow thread to sleep for 1 sec before we run analytic export.
