### PR TITLE
Clean branch name for action runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,10 +44,10 @@ jobs:
         run:  docker image list
       - name: Publish Images
         working-directory: rtsl_util
-        run:  docker push simpledotorg/prometheusdbexporter:${{github.ref_name}}.${{github.run_number}}
+        run:  docker push simpledotorg/prometheusdbexporter:${{ env.CLEAN_BRANCH_NAME }}.${{github.run_number}}
       - name: Archive Dhis2TestTool jar file
         uses: actions/upload-artifact@v4
         with:
-          name: Dhis2CucumberTestTool-${{github.ref_name}}.${{github.run_number}}.jar
-          path: rtsl_util/CommonUtils/Dhis2CucumberTestTool/target/Dhis2CucumberTestTool-${{github.ref_name}}.${{github.run_number}}.jar
+          name: Dhis2CucumberTestTool-${{ env.CLEAN_BRANCH_NAME }}.${{github.run_number}}.jar
+          path: rtsl_util/CommonUtils/Dhis2CucumberTestTool/target/Dhis2CucumberTestTool-${{ env.CLEAN_BRANCH_NAME }}.${{github.run_number}}.jar
       - run: find . -name "*.jar"


### PR DESCRIPTION
This is purely a QoL improvement.

I namespace my branches, using `/` as a delimiter. There's a step currently in our `build.yml` workflow which sets the new version to the branch name for Maven operations. When a Maven version has a `/` in it, it breaks the build.

This here is to ensure that we have the proper characters in a potential Maven version.
