### PR TITLE
build(Dhis2Verifier): Set the tagname to the ref

### DIFF
--- a/.github/workflows/publish-dhis2-verifier.yml
+++ b/.github/workflows/publish-dhis2-verifier.yml
@@ -23,8 +23,7 @@ jobs:
           settings-path: ${{ github.workspace }}
       - name: Set the version
         run: |
-          echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-          mvn versions:set -DnewVersion=${{ env.RELEASE_VERSION }}
+          mvn versions:set -DnewVersion=${{ github.ref_name }}
       - name: Build with Maven
         run: mvn -B package --file pom.xml -DskipTests=true
       - name: Create a release with the artefacts  # Note: this would create a new release…


### PR DESCRIPTION
Since the workflow only runs on push for tags, we can assume that the
`ref_name` would never be a branch name.
