### PR TITLE
build(Dhis2Verifier): ensure the version is repo-wide

### DIFF
--- a/.github/workflows/publish-dhis2-verifier.yml
+++ b/.github/workflows/publish-dhis2-verifier.yml
@@ -22,6 +22,7 @@ jobs:
           server-id: github
           settings-path: ${{ github.workspace }}
       - name: Set the version
+        working-directory: .
         run: |
           mvn versions:set -DnewVersion=${{ github.ref_name }}
       - name: Build with Maven

--- a/docker_build/Dhis2Verifier.Dockerfile
+++ b/docker_build/Dhis2Verifier.Dockerfile
@@ -1,0 +1,14 @@
+from maven:3.9-amazoncorretto-21 as packager
+
+arg VERSION
+
+env HOME=/rtsl/utils
+run mkdir -p $HOME
+workdir $HOME
+add . $HOME
+workdir $HOME/CommonUtils/Dhis2CucumberTestTool
+
+run --mount=type=cache,target=$HOME/.m2 mvn clean package
+
+# this docker file must not built the mvn package
+# it should only copy the JAR into the docker image


### PR DESCRIPTION
This is a decision we may have to revisit in the future. Right now, we
cannot release independent versions of tooling within the repository.
This is because the Maven packages depends on versioned POMs, and we
currently are not publishing these POMs anywhere. So there's no way for
us to independently pin versions on anything since we would not be able
to find said versions anywhere. Difficulty with this is, releasing a
breaking change in one tool means a breaking change in every tool; which
technically isn't true, and isn't a good experience for the community.
