### PR TITLE
build(Dhis2Verifier): Build using Java 21

### DIFF
--- a/.github/workflows/publish-dhis2-verifier.yml
+++ b/.github/workflows/publish-dhis2-verifier.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v3
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: 'maven'
           server-id: github


### PR DESCRIPTION
Originally had this built using 17, but for some reason the grandfather
POM requires Java 21
