### PR TITLE
Removing obsolete attribute from the tei template

### DIFF
--- a/CommonUtils/Dhis2Verifier/src/main/resources/templates/create_and_enroll_tei.tpl.json
+++ b/CommonUtils/Dhis2Verifier/src/main/resources/templates/create_and_enroll_tei.tpl.json
@@ -4,12 +4,7 @@
       "orgUnit": "${data.orgUnitId}",
       "trackedEntity": "${data.teiId}",
       "trackedEntityType": "MCPQUTHX1Ze",
-      "attributes": [
-        {
-          "attribute": "D9pz1vAbGPK",
-          "value": true
-        }
-      ]
+      "attributes": []
     }
   ],
   "enrollments": [


### PR DESCRIPTION
There is a tracked entity attribute "Enabler for autofilling fields"  present in sandbox2, which is now obsolete. 
Test template still uses this, and fails at execution for a fresh package installation.
Removing this from template should fix this.