### PR TITLE
removing district from patient creation

### DIFF
--- a/CommonUtils/Dhis2Verifier/src/test/resources/local_tests/scenarios/hypertension/hypertension_contactable_overdue_patients.feature
+++ b/CommonUtils/Dhis2Verifier/src/test/resources/local_tests/scenarios/hypertension/hypertension_contactable_overdue_patients.feature
@@ -20,7 +20,6 @@ Feature: Contactable Overdue Patients
       | GEN - Date of birth                   | 32           |
       | Address (current)                     | Rose Gardens |
       | Patient Phone Number                  | 345672781624 |
-      | District                              | KOLARA       |
       | HTN - Consent to record data          | true         |
       | HTN - NCD Patient Status              | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "7_MonthsAgo" with following data
@@ -36,7 +35,6 @@ Feature: Contactable Overdue Patients
       | HTN - Does patient have diabetes?     | YES          |
       | GEN - Date of birth                   | 32           |
       | Address (current)                     | Rose Gardens |
-      | District                              | KOLARA       |
       | HTN - Consent to record data          | true         |
       | HTN - NCD Patient Status              | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "7_MonthsAgo" with following data
@@ -76,7 +74,6 @@ Feature: Contactable Overdue Patients
       | GEN - Date of birth                   | 32           |
       | Address (current)                     | Rose Gardens |
       | Patient Phone Number                  | 345672781624 |
-      | District                              | KOLARA       |
       | HTN - Consent to record data          | true         |
       | HTN - NCD Patient Status              | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "7_MonthsAgo" with following data
@@ -93,7 +90,6 @@ Feature: Contactable Overdue Patients
       | GEN - Date of birth                   | 32           |
       | Address (current)                     | Rose Gardens |
       | Patient Phone Number                  | 345672781624 |
-      | District                              | KOLARA       |
       | HTN - Consent to record data          | true         |
       | HTN - NCD Patient Status              | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "7_MonthsAgo" with following data
@@ -133,7 +129,6 @@ Feature: Contactable Overdue Patients
       | GEN - Date of birth                   | 32           |
       | Address (current)                     | Rose Gardens |
       | Patient Phone Number                  | 345672781624 |
-      | District                              | KOLARA       |
       | HTN - Consent to record data          | true         |
       | HTN - NCD Patient Status              | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "7_MonthsAgo" with following data
@@ -150,7 +145,6 @@ Feature: Contactable Overdue Patients
       | GEN - Date of birth                   | 32           |
       | Address (current)                     | Rose Gardens |
       | Patient Phone Number                  | 345672781624 |
-      | District                              | KOLARA       |
       | HTN - Consent to record data          | true         |
       | HTN - NCD Patient Status              | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "7_MonthsAgo" with following data
@@ -192,7 +186,6 @@ Feature: Contactable Overdue Patients
       | GEN - Date of birth                   | 32           |
       | Address (current)                     | Rose Gardens |
       | Patient Phone Number                  | 345672781624 |
-      | District                              | KOLARA       |
       | HTN - Consent to record data          | true         |
       | HTN - NCD Patient Status              | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "7_MonthsAgo" with following data
@@ -209,7 +202,6 @@ Feature: Contactable Overdue Patients
       | GEN - Date of birth                   | 32           |
       | Address (current)                     | Rose Gardens |
       | Patient Phone Number                  | 345672781624 |
-      | District                              | KOLARA       |
       | HTN - Consent to record data          | true         |
       | HTN - NCD Patient Status              | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "7_MonthsAgo" with following data
@@ -230,7 +222,6 @@ Feature: Contactable Overdue Patients
       | HTN - Does patient have diabetes?     | YES          |
       | GEN - Date of birth                   | 32           |
       | Address (current)                     | Rose Gardens |
-      | District                              | KOLARA       |
       | HTN - Consent to record data          | true         |
       | HTN - NCD Patient Status              | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "7_MonthsAgo" with following data

--- a/CommonUtils/Dhis2Verifier/src/test/resources/local_tests/scenarios/hypertension/hypertension_contactable_overdue_patients_called.feature
+++ b/CommonUtils/Dhis2Verifier/src/test/resources/local_tests/scenarios/hypertension/hypertension_contactable_overdue_patients_called.feature
@@ -20,7 +20,6 @@ Feature: Contactable overdue patients called
       | GEN - Date of birth                   | 32           |
       | Address (current)                     | Rose Gardens |
       | Patient Phone Number                  | 345672781624 |
-      | District                              | KOLARA       |
       | HTN - Consent to record data          | true         |
       | HTN - NCD Patient Status              | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "7_MonthsAgo" with following data
@@ -56,7 +55,6 @@ Feature: Contactable overdue patients called
       | GEN - Date of birth                   | 32           |
       | Address (current)                     | Rose Gardens |
       | Patient Phone Number                  | 345672781624 |
-      | District                              | KOLARA       |
       | HTN - Consent to record data          | true         |
       | HTN - NCD Patient Status              | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "7_MonthsAgo" with following data
@@ -91,7 +89,6 @@ Feature: Contactable overdue patients called
       | HTN - Does patient have diabetes?     | YES          |
       | GEN - Date of birth                   | 32           |
       | Address (current)                     | By the beach |
-      | District                              | KOLARA       |
       | HTN - Consent to record data          | true         |
       | HTN - NCD Patient Status              | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "7_MonthsAgo" with following data
@@ -107,7 +104,6 @@ Feature: Contactable overdue patients called
       | HTN - Does patient have diabetes?     | YES          |
       | GEN - Date of birth                   | 32           |
       | Address (current)                     | By the beach |
-      | District                              | KOLARA       |
       | HTN - Consent to record data          | true         |
       | HTN - NCD Patient Status              | ACTIVE       |
     And That TEI has a "Calling report" event on "4_MonthsAgo" with following data

--- a/CommonUtils/Dhis2Verifier/src/test/resources/local_tests/scenarios/hypertension/hypertension_contactable_overdue_patients_called_and_returned_to_care.feature
+++ b/CommonUtils/Dhis2Verifier/src/test/resources/local_tests/scenarios/hypertension/hypertension_contactable_overdue_patients_called_and_returned_to_care.feature
@@ -20,7 +20,6 @@ Feature: Contactable patients called and returned to care
       | GEN - Date of birth                   | 32           |
       | Address (current)                     | Rose Gardens |
       | Patient Phone Number                  | 345672781624 |
-      | District                              | KOLARA       |
       | HTN - Consent to record data          | true         |
       | HTN - NCD Patient Status              | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "7_MonthsAgo" with following data
@@ -54,7 +53,6 @@ Feature: Contactable patients called and returned to care
       | HTN - Does patient have diabetes?     | YES          |
       | GEN - Date of birth                   | 32           |
       | Address (current)                     | Rose Gardens |
-      | District                              | KOLARA       |
       | HTN - Consent to record data          | true         |
       | HTN - NCD Patient Status              | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "7_MonthsAgo" with following data
@@ -89,7 +87,6 @@ Feature: Contactable patients called and returned to care
       | GEN - Date of birth                   | 32           |
       | Address (current)                     | Rose Gardens |
       | Patient Phone Number                  | 345672781624 |
-      | District                              | KOLARA       |
       | HTN - Consent to record data          | true         |
       | HTN - NCD Patient Status              | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "7_MonthsAgo" with following data
@@ -121,7 +118,6 @@ Feature: Contactable patients called and returned to care
       | GEN - Date of birth                   | 32           |
       | Address (current)                     | Rose Gardens |
       | Patient Phone Number                  | 345672781624 |
-      | District                              | KOLARA       |
       | HTN - Consent to record data          | true         |
       | HTN - NCD Patient Status              | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "7_MonthsAgo" with following data
@@ -156,7 +152,6 @@ Feature: Contactable patients called and returned to care
       | GEN - Date of birth                   | 32           |
       | Address (current)                     | Rose Gardens |
       | Patient Phone Number                  | 345672781624 |
-      | District                              | KOLARA       |
       | HTN - Consent to record data          | true         |
       | HTN - NCD Patient Status              | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "7_MonthsAgo" with following data
@@ -191,7 +186,6 @@ Feature: Contactable patients called and returned to care
       | GEN - Date of birth                   | 32           |
       | Address (current)                     | Rose Gardens |
       | Patient Phone Number                  | 345672781624 |
-      | District                              | KOLARA       |
       | HTN - Consent to record data          | true         |
       | HTN - NCD Patient Status              | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "7_MonthsAgo" with following data
@@ -225,7 +219,6 @@ Feature: Contactable patients called and returned to care
       | GEN - Date of birth                   | 32           |
       | Address (current)                     | Rose Gardens |
       | Patient Phone Number                  | 345672781624 |
-      | District                              | KOLARA       |
       | HTN - Consent to record data          | true         |
       | HTN - NCD Patient Status              | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "7_MonthsAgo" with following data
@@ -258,7 +251,6 @@ Feature: Contactable patients called and returned to care
       | GEN - Date of birth                   | 32           |
       | Address (current)                     | Rose Gardens |
       | Patient Phone Number                  | 345672781624 |
-      | District                              | KOLARA       |
       | HTN - Consent to record data          | true         |
       | HTN - NCD Patient Status              | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "13_MonthsAgo" with following data
@@ -293,7 +285,6 @@ Feature: Contactable patients called and returned to care
       | GEN - Date of birth                   | 32           |
       | Address (current)                     | Rose Gardens |
       | Patient Phone Number                  | 345672781624 |
-      | District                              | KOLARA       |
       | HTN - Consent to record data          | true         |
       | HTN - NCD Patient Status              | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "7_MonthsAgo" with following data

--- a/CommonUtils/Dhis2Verifier/src/test/resources/local_tests/scenarios/hypertension/hypertension_cumulative_registration.feature
+++ b/CommonUtils/Dhis2Verifier/src/test/resources/local_tests/scenarios/hypertension/hypertension_cumulative_registration.feature
@@ -16,7 +16,6 @@ Feature: Audit HTN - Cumulative registrations
       | HTN - Does patient have diabetes?     | YES          |
       | GEN - Date of birth                   | 32           |
       | Address (current)                     | Rose Gardens |
-      | District                              | KOLARA       |
       | HTN - Consent to record data          | true         |
       | HTN - NCD Patient Status              | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "7_MonthsAgo" with following data
@@ -42,7 +41,6 @@ Feature: Audit HTN - Cumulative registrations
       | DM diagnosis       | YES          |
       | Date of birth      | 32           |
       | Address            | Rose Gardens |
-      | District           | KOLARA       |
       | Data consent       | true         |
       | NCD Patient Status | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "7_MonthsAgo" with following data
@@ -61,7 +59,6 @@ Feature: Audit HTN - Cumulative registrations
       | v4DnYfXn9Mu        | YES          |
       | NI0QRzJvQ0k        | 32           |
       | Address            | Rose Gardens |
-      | District           | KOLARA       |
       | Data consent       | true         |
       | NCD Patient Status | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "9_MonthsAgo" with following data
@@ -91,7 +88,6 @@ Feature: Audit HTN - Cumulative registrations
       | v4DnYfXn9Mu        | YES          |
       | NI0QRzJvQ0k        | 32           |
       | Address            | Rose Gardens |
-      | District           | KOLARA       |
       | Data consent       | true         |
       | NCD Patient Status | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "9_MonthsAgo" with following data
@@ -159,7 +155,6 @@ Feature: Audit HTN - Cumulative registrations
       | DM diagnosis       | YES          |
       | Date of birth      | 32           |
       | Address            | Rose Gardens |
-      | District           | KOLARA       |
       | Data consent       | true         |
       | NCD Patient Status | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "7_MonthsAgo" with following data
@@ -178,7 +173,6 @@ Feature: Audit HTN - Cumulative registrations
       | v4DnYfXn9Mu        | YES          |
       | NI0QRzJvQ0k        | 32           |
       | Address            | Rose Gardens |
-      | District           | KOLARA       |
       | Data consent       | true         |
       | NCD Patient Status | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "10_MonthsAgo" with following data
@@ -208,7 +202,6 @@ Feature: Audit HTN - Cumulative registrations
       | v4DnYfXn9Mu        | YES          |
       | NI0QRzJvQ0k        | 32           |
       | Address            | Rose Gardens |
-      | District           | KOLARA       |
       | Data consent       | true         |
       | NCD Patient Status | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "10_MonthsAgo" with following data
@@ -262,7 +255,6 @@ Feature: Audit HTN - Cumulative registrations
       | HTN - Does patient have diabetes?     | YES          |
       | GEN - Date of birth                   | 32           |
       | Address (current)                     | Rose Gardens |
-      | District                              | KOLARA       |
       | HTN - Consent to record data          | true         |
       | HTN - NCD Patient Status              | ACTIVE       |
 
@@ -287,7 +279,6 @@ Feature: Audit HTN - Cumulative registrations
       | v4DnYfXn9Mu        | YES          |
       | NI0QRzJvQ0k        | 32           |
       | Address            | Rose Gardens |
-      | District           | KOLARA       |
       | Data consent       | true         |
       | NCD Patient Status | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "8_MonthsAgo" with following data
@@ -319,7 +310,6 @@ Feature: Audit HTN - Cumulative registrations
       | v4DnYfXn9Mu        | YES          |
       | NI0QRzJvQ0k        | 32           |
       | Address            | Rose Gardens |
-      | District           | KOLARA       |
       | Data consent       | true         |
       | NCD Patient Status | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "10_MonthsAgo" with following data

--- a/CommonUtils/Dhis2Verifier/src/test/resources/local_tests/scenarios/hypertension/hypertension_data_audit.feature
+++ b/CommonUtils/Dhis2Verifier/src/test/resources/local_tests/scenarios/hypertension/hypertension_data_audit.feature
@@ -22,7 +22,6 @@ Feature: Hypertension Data Audit
       | DM diagnosis       | YES          |
       | Date of birth      | 32           |
       | Address            | Rose Gardens |
-      | District           | KOLARA       |
       | Data consent       | true         |
       | NCD Patient Status | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "7_MonthsAgo" with following data
@@ -47,7 +46,6 @@ Feature: Hypertension Data Audit
       | DM diagnosis       | YES          |
       | Date of birth      | 32           |
       | Address            | Rose Gardens |
-      | District           | KOLARA       |
       | Data consent       | true         |
       | NCD Patient Status | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "5_MonthsAgo" with following data
@@ -64,7 +62,6 @@ Feature: Hypertension Data Audit
       | DM diagnosis       | YES          |
       | Date of birth      | 32           |
       | Address            | Rose Gardens |
-      | District           | KOLARA       |
       | Data consent       | true         |
       | NCD Patient Status | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "10_MonthsAgo" with following data
@@ -96,7 +93,6 @@ Feature: Hypertension Data Audit
       | DM diagnosis       | YES          |
       | Date of birth      | 32           |
       | Address            | Rose Gardens |
-      | District           | KOLARA       |
       | Data consent       | true         |
       | NCD Patient Status | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "19_MonthsAgo" with following data
@@ -125,7 +121,6 @@ Feature: Hypertension Data Audit
       | DM diagnosis       | YES          |
       | Date of birth      | 42           |
       | Address            | Rose Gardens |
-      | District           | KOLARA       |
       | Data consent       | true         |
       | NCD Patient Status | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "8_MonthsAgo" with following data
@@ -157,7 +152,6 @@ Feature: Hypertension Data Audit
       | DM diagnosis       | YES          |
       | Date of birth      | 42           |
       | Address            | Rose Gardens |
-      | District           | KOLARA       |
       | Data consent       | true         |
       | NCD Patient Status | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "12_MonthsAgo" with following data
@@ -189,7 +183,6 @@ Feature: Hypertension Data Audit
       | DM diagnosis       | YES          |
       | Date of birth      | 42           |
       | Address            | Rose Gardens |
-      | District           | KOLARA       |
       | Data consent       | true         |
       | NCD Patient Status | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "4_MonthsAgo" with following data
@@ -212,7 +205,6 @@ Feature: Hypertension Data Audit
       | DM diagnosis       | YES          |
       | Date of birth      | 42           |
       | Address            | Rose Gardens |
-      | District           | KOLARA       |
       | Data consent       | true         |
       | NCD Patient Status | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "16_MonthsAgo" with following data
@@ -229,7 +221,6 @@ Feature: Hypertension Data Audit
       | DM diagnosis       | YES          |
       | Date of birth      | 42           |
       | Address            | Rose Gardens |
-      | District           | KOLARA       |
       | Data consent       | true         |
       | NCD Patient Status | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "6_MonthsAgo" with following data
@@ -258,7 +249,6 @@ Feature: Hypertension Data Audit
       | DM diagnosis       | YES          |
       | Date of birth      | 42           |
       | Address            | Rose Gardens |
-      | District           | KOLARA       |
       | Data consent       | true         |
       | NCD Patient Status | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "8_MonthsAgo" with following data
@@ -281,7 +271,6 @@ Feature: Hypertension Data Audit
       | DM diagnosis       | YES          |
       | Date of birth      | 42           |
       | Address            | Rose Gardens |
-      | District           | KOLARA       |
       | Data consent       | true         |
       | NCD Patient Status | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "9_MonthsAgo" with following data
@@ -447,7 +436,6 @@ Feature: Hypertension Data Audit
       | DM diagnosis       | YES          |
       | Date of birth      | 32           |
       | Address            | Rose Gardens |
-      | District           | KOLARA       |
       | Data consent       | true         |
       | NCD Patient Status | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "3_QuartersAgo" with following data
@@ -472,7 +460,6 @@ Feature: Hypertension Data Audit
       | DM diagnosis       | YES          |
       | Date of birth      | 32           |
       | Address            | Rose Gardens |
-      | District           | KOLARA       |
       | Data consent       | true         |
       | NCD Patient Status | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "3_QuarterAgo" with following data
@@ -489,7 +476,6 @@ Feature: Hypertension Data Audit
       | DM diagnosis       | YES          |
       | Date of birth      | 32           |
       | Address            | Rose Gardens |
-      | District           | KOLARA       |
       | Data consent       | true         |
       | NCD Patient Status | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "4_QuartersAgo" with following data
@@ -521,7 +507,6 @@ Feature: Hypertension Data Audit
       | DM diagnosis       | YES          |
       | Date of birth      | 32           |
       | Address            | Rose Gardens |
-      | District           | KOLARA       |
       | Data consent       | true         |
       | NCD Patient Status | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "3_QuartersAgo" with following data
@@ -550,7 +535,6 @@ Feature: Hypertension Data Audit
       | DM diagnosis       | YES          |
       | Date of birth      | 42           |
       | Address            | Rose Gardens |
-      | District           | KOLARA       |
       | Data consent       | true         |
       | NCD Patient Status | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "4_QuartersAgo_Plus_2_Months" with following data
@@ -582,7 +566,6 @@ Feature: Hypertension Data Audit
       | DM diagnosis       | YES          |
       | Date of birth      | 42           |
       | Address            | Rose Gardens |
-      | District           | KOLARA       |
       | Data consent       | true         |
       | NCD Patient Status | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "5_QuartersAgo" with following data
@@ -614,7 +597,6 @@ Feature: Hypertension Data Audit
       | DM diagnosis       | YES          |
       | Date of birth      | 42           |
       | Address            | Rose Gardens |
-      | District           | KOLARA       |
       | Data consent       | true         |
       | NCD Patient Status | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "3_QuartersAgo" with following data
@@ -637,7 +619,6 @@ Feature: Hypertension Data Audit
       | DM diagnosis       | YES          |
       | Date of birth      | 42           |
       | Address            | Rose Gardens |
-      | District           | KOLARA       |
       | Data consent       | true         |
       | NCD Patient Status | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "2_QuartersAgo" with following data
@@ -654,7 +635,6 @@ Feature: Hypertension Data Audit
       | DM diagnosis       | YES          |
       | Date of birth      | 42           |
       | Address            | Rose Gardens |
-      | District           | KOLARA       |
       | Data consent       | true         |
       | NCD Patient Status | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "2_QuartersAgo" with following data
@@ -683,7 +663,6 @@ Feature: Hypertension Data Audit
       | DM diagnosis       | YES          |
       | Date of birth      | 42           |
       | Address            | Rose Gardens |
-      | District           | KOLARA       |
       | Data consent       | true         |
       | NCD Patient Status | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "3_QuartersAgo" with following data
@@ -706,7 +685,6 @@ Feature: Hypertension Data Audit
       | DM diagnosis       | YES          |
       | Date of birth      | 42           |
       | Address            | Rose Gardens |
-      | District           | KOLARA       |
       | Data consent       | true         |
       | NCD Patient Status | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "3_QuartersAgo" with following data

--- a/CommonUtils/Dhis2Verifier/src/test/resources/local_tests/scenarios/hypertension/hypertension_overdue_patients.feature
+++ b/CommonUtils/Dhis2Verifier/src/test/resources/local_tests/scenarios/hypertension/hypertension_overdue_patients.feature
@@ -19,7 +19,6 @@ Feature: Number of overdue patients
       | HTN - Does patient have diabetes?     | YES          |
       | GEN - Date of birth                   | 32           |
       | Address (current)                     | Rose Gardens |
-      | District                              | KOLARA       |
       | HTN - Consent to record data          | true         |
       | HTN - NCD Patient Status              | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "7_MonthsAgo" with following data
@@ -35,7 +34,6 @@ Feature: Number of overdue patients
       | HTN - Does patient have diabetes?     | YES          |
       | GEN - Date of birth                   | 32           |
       | Address (current)                     | Rose Gardens |
-      | District                              | KOLARA       |
       | HTN - Consent to record data          | true         |
       | HTN - NCD Patient Status              | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "7_MonthsAgo" with following data
@@ -74,7 +72,6 @@ Feature: Number of overdue patients
       | HTN - Does patient have diabetes?     | YES          |
       | GEN - Date of birth                   | 32           |
       | Address (current)                     | Rose Gardens |
-      | District                              | KOLARA       |
       | HTN - Consent to record data          | true         |
       | HTN - NCD Patient Status              | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "7_MonthsAgo" with following data
@@ -90,7 +87,6 @@ Feature: Number of overdue patients
       | HTN - Does patient have diabetes?     | YES          |
       | GEN - Date of birth                   | 32           |
       | Address (current)                     | Rose Gardens |
-      | District                              | KOLARA       |
       | HTN - Consent to record data          | true         |
       | HTN - NCD Patient Status              | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "7_MonthsAgo" with following data
@@ -131,7 +127,6 @@ Feature: Number of overdue patients
       | HTN - Does patient have diabetes?     | YES          |
       | GEN - Date of birth                   | 32           |
       | Address (current)                     | Rose Gardens |
-      | District                              | KOLARA       |
       | HTN - Consent to record data          | true         |
       | HTN - NCD Patient Status              | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "7_MonthsAgo" with following data
@@ -147,7 +142,6 @@ Feature: Number of overdue patients
       | HTN - Does patient have diabetes?     | YES          |
       | GEN - Date of birth                   | 32           |
       | Address (current)                     | Rose Gardens |
-      | District                              | KOLARA       |
       | HTN - Consent to record data          | true         |
       | HTN - NCD Patient Status              | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "7_MonthsAgo" with following data

--- a/CommonUtils/Dhis2Verifier/src/test/resources/local_tests/scenarios/hypertension/hypertension_overdue_patients_called.feature
+++ b/CommonUtils/Dhis2Verifier/src/test/resources/local_tests/scenarios/hypertension/hypertension_overdue_patients_called.feature
@@ -19,7 +19,6 @@ Feature: Number of overdue patients called
       | HTN - Does patient have diabetes?     | YES          |
       | GEN - Date of birth                   | 32           |
       | Address (current)                     | Rose Gardens |
-      | District                              | KOLARA       |
       | HTN - Consent to record data          | true         |
       | HTN - NCD Patient Status              | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "7_MonthsAgo" with following data
@@ -55,7 +54,6 @@ Feature: Number of overdue patients called
       | HTN - Does patient have diabetes?     | YES          |
       | GEN - Date of birth                   | 32           |
       | Address (current)                     | Rose Gardens |
-      | District                              | KOLARA       |
       | HTN - Consent to record data          | true         |
       | HTN - NCD Patient Status              | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "7_MonthsAgo" with following data
@@ -91,7 +89,6 @@ Feature: Number of overdue patients called
       | HTN - Does patient have diabetes?     | YES          |
       | GEN - Date of birth                   | 32           |
       | Address (current)                     | By the beach |
-      | District                              | KOLARA       |
       | HTN - Consent to record data          | true         |
       | HTN - NCD Patient Status              | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "7_MonthsAgo" with following data
@@ -107,7 +104,6 @@ Feature: Number of overdue patients called
       | HTN - Does patient have diabetes?     | YES           |
       | GEN - Date of birth                   | 32            |
       | Address (current)                     | By the beach  |
-      | District                              | KOLARA        |
       | HTN - Consent to record data          | true          |
       | HTN - NCD Patient Status              | ACTIVE        |
     And That TEI has a "Calling report" event on "4_MonthsAgo" with following data
@@ -121,7 +117,6 @@ Feature: Number of overdue patients called
       | HTN - Does patient have diabetes?     | YES          |
       | GEN - Date of birth                   | 32           |
       | Address (current)                     | New Home     |
-      | District                              | KOLARA       |
       | HTN - Consent to record data          | true         |
       | HTN - NCD Patient Status              | ACTIVE       |
     And That TEI has a "Calling report" event on "4_MonthsAgo" with following data

--- a/CommonUtils/Dhis2Verifier/src/test/resources/local_tests/scenarios/hypertension/hypertension_overdue_patients_called_returned_to_care.feature
+++ b/CommonUtils/Dhis2Verifier/src/test/resources/local_tests/scenarios/hypertension/hypertension_overdue_patients_called_returned_to_care.feature
@@ -19,7 +19,6 @@ Feature: Number of overdue patients
       | HTN - Does patient have diabetes?     | YES          |
       | GEN - Date of birth                   | 32           |
       | Address (current)                     | Rose Gardens |
-      | District                              | KOLARA       |
       | HTN - Consent to record data          | true         |
       | HTN - NCD Patient Status              | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "7_MonthsAgo" with following data
@@ -53,7 +52,6 @@ Feature: Number of overdue patients
       | HTN - Does patient have diabetes?     | YES          |
       | GEN - Date of birth                   | 32           |
       | Address (current)                     | Rose Gardens |
-      | District                              | KOLARA       |
       | HTN - Consent to record data          | true         |
       | HTN - NCD Patient Status              | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "7_MonthsAgo" with following data
@@ -84,7 +82,6 @@ Feature: Number of overdue patients
       | HTN - Does patient have diabetes?     | YES          |
       | GEN - Date of birth                   | 32           |
       | Address (current)                     | Rose Gardens |
-      | District                              | KOLARA       |
       | HTN - Consent to record data          | true         |
       | HTN - NCD Patient Status              | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "7_MonthsAgo" with following data
@@ -118,7 +115,6 @@ Feature: Number of overdue patients
       | HTN - Does patient have diabetes?     | YES          |
       | GEN - Date of birth                   | 32           |
       | Address (current)                     | Rose Gardens |
-      | District                              | KOLARA       |
       | HTN - Consent to record data          | true         |
       | HTN - NCD Patient Status              | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "7_MonthsAgo" with following data
@@ -152,7 +148,6 @@ Feature: Number of overdue patients
       | HTN - Does patient have diabetes?     | YES          |
       | GEN - Date of birth                   | 32           |
       | Address (current)                     | Rose Gardens |
-      | District                              | KOLARA       |
       | HTN - Consent to record data          | true         |
       | HTN - NCD Patient Status              | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "7_MonthsAgo" with following data
@@ -185,7 +180,6 @@ Feature: Number of overdue patients
       | HTN - Does patient have diabetes?     | YES          |
       | GEN - Date of birth                   | 32           |
       | Address (current)                     | Rose Gardens |
-      | District                              | KOLARA       |
       | HTN - Consent to record data          | true         |
       | HTN - NCD Patient Status              | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "7_MonthsAgo" with following data
@@ -217,7 +211,6 @@ Feature: Number of overdue patients
       | HTN - Does patient have diabetes?     | YES          |
       | GEN - Date of birth                   | 32           |
       | Address (current)                     | Rose Gardens |
-      | District                              | KOLARA       |
       | HTN - Consent to record data          | true         |
       | HTN - NCD Patient Status              | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "13_MonthsAgo" with following data
@@ -251,7 +244,6 @@ Feature: Number of overdue patients
       | HTN - Does patient have diabetes?     | YES          |
       | GEN - Date of birth                   | 32           |
       | Address (current)                     | Rose Gardens |
-      | District                              | KOLARA       |
       | HTN - Consent to record data          | true         |
       | HTN - NCD Patient Status              | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "7_MonthsAgo" with following data

--- a/CommonUtils/Dhis2Verifier/src/test/resources/local_tests/scenarios/hypertension/hypertension_patient_under_care_controlled.feature
+++ b/CommonUtils/Dhis2Verifier/src/test/resources/local_tests/scenarios/hypertension/hypertension_patient_under_care_controlled.feature
@@ -18,7 +18,6 @@
    | HTN - Does patient have diabetes?     | YES          |
    | GEN - Date of birth                   | 32           |
    | Address (current)                     | Rose Gardens |
-   | District                              | KOLARA       |
    | HTN - Consent to record data          | true         |
    | HTN - NCD Patient Status              | ACTIVE       |
   And That TEI has a "Hypertension & Diabetes visit" event on "7_monthsAgo" with following data

--- a/CommonUtils/Dhis2Verifier/src/test/resources/local_tests/scenarios/hypertension/hypertension_patient_under_registered_before_past_3_months.feature
+++ b/CommonUtils/Dhis2Verifier/src/test/resources/local_tests/scenarios/hypertension/hypertension_patient_under_registered_before_past_3_months.feature
@@ -16,7 +16,6 @@ Feature: Audit the program indicator: HTN - Patients under care registered befor
       | DM diagnosis       | YES          |
       | Date of birth      | 32           |
       | Address            | Rose Gardens |
-      | District           | KOLARA       |
       | Data consent       | true         |
       | NCD Patient Status | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "7_MonthsAgo" with following data
@@ -47,7 +46,6 @@ Feature: Audit the program indicator: HTN - Patients under care registered befor
       | v4DnYfXn9Mu        | YES          |
       | NI0QRzJvQ0k        | 32           |
       | Address            | Rose Gardens |
-      | District           | KOLARA       |
       | Data consent       | true         |
       | NCD Patient Status | ACTIVE       |
 
@@ -100,7 +98,6 @@ Feature: Audit the program indicator: HTN - Patients under care registered befor
       | DM diagnosis       | YES          |
       | Date of birth      | 32           |
       | Address            | Rose Gardens |
-      | District           | KOLARA       |
       | Data consent       | true         |
       | NCD Patient Status | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "6_MonthsAgo" with following data
@@ -138,7 +135,6 @@ Feature: Audit the program indicator: HTN - Patients under care registered befor
       | v4DnYfXn9Mu        | YES          |
       | NI0QRzJvQ0k        | 32           |
       | Address            | Rose Gardens |
-      | District           | KOLARA       |
       | Data consent       | true         |
       | NCD Patient Status | ACTIVE       |
 
@@ -191,7 +187,6 @@ Feature: Audit the program indicator: HTN - Patients under care registered befor
       | DM diagnosis       | NO           |
       | Date of birth      | 32           |
       | Address            | Rose Gardens |
-      | District           | KOLARA       |
       | Data consent       | true         |
       | NCD Patient Status | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "10_MonthsAgo" with following data
@@ -224,7 +219,6 @@ Feature: Audit the program indicator: HTN - Patients under care registered befor
       | v4DnYfXn9Mu        | YES          |
       | NI0QRzJvQ0k        | 32           |
       | Address            | Rose Gardens |
-      | District           | KOLARA       |
       | Data consent       | true         |
       | NCD Patient Status | ACTIVE       |
 
@@ -277,7 +271,6 @@ Feature: Audit the program indicator: HTN - Patients under care registered befor
       | DM diagnosis       | NO           |
       | Date of birth      | 32           |
       | Address            | Rose Gardens |
-      | District           | KOLARA       |
       | Data consent       | true         |
       | NCD Patient Status | ACTIVE       |
 
@@ -305,7 +298,6 @@ Feature: Audit the program indicator: HTN - Patients under care registered befor
       | v4DnYfXn9Mu        | NO           |
       | NI0QRzJvQ0k        | 32           |
       | Address            | Rose Gardens |
-      | District           | KOLARA       |
       | Data consent       | true         |
       | NCD Patient Status | ACTIVE       |
 
@@ -336,7 +328,6 @@ Feature: Audit the program indicator: HTN - Patients under care registered befor
       | DM diagnosis       | NO           |
       | Date of birth      | 32           |
       | Address            | Rose Gardens |
-      | District           | KOLARA       |
       | Data consent       | true         |
       | NCD Patient Status | ACTIVE       |
     And That TEI has a "Hypertension & Diabetes visit" event on "18_MonthsAgo" with following data


### PR DESCRIPTION
[Story](https://app.shortcut.com/simpledotorg/story/14019/remove-state-and-district-from-automation-test-suite)
Oue HTN-DM DHIS2 package is not supposed to have District and State in the program.
In the test suite features "district" was being passed as a parameter while creating a patient, which was causing the tests to fail, hence removing it.
