### PR TITLE
Adding 1 sec wait for overdue called feature

### DIFF
--- a/CommonUtils/Dhis2Verifier/src/test/resources/local_tests/scenarios/hypertension/hypertension_overdue_patients_called.feature
+++ b/CommonUtils/Dhis2Verifier/src/test/resources/local_tests/scenarios/hypertension/hypertension_overdue_patients_called.feature
@@ -31,6 +31,7 @@ Feature: Number of overdue patients called
       | Result of call                          | REMOVE_FROM_OVERDUE |
       | HTN - Remove from overdue list because: | OTHER               |
 
+    And I wait for 1 second
     When I export the analytics
     And I wait for 1 second
 
@@ -65,6 +66,7 @@ Feature: Number of overdue patients called
       | Result of call                          | REMOVE_FROM_OVERDUE |
       | HTN - Remove from overdue list because: | OTHER               |
 
+    And I wait for 1 second
     When I export the analytics
     And I wait for 1 second
 


### PR DESCRIPTION
Overdue called feature file had couple of failures.
Adding 1 sec wait before running the analytics, provides enough time for the triggers to finish up for accurate indicator calculations.