### PR TITLE
Fix package paths

### DIFF
--- a/CommonUtils/Dhis2Verifier/src/main/java/org/rtsl/dhis2/cucumber/Dhis2HttpClient.java
+++ b/CommonUtils/Dhis2Verifier/src/main/java/org/rtsl/dhis2/cucumber/Dhis2HttpClient.java
@@ -1,4 +1,4 @@
-package org.rtsl.dhis2.cucumber.utils;
+package org.rtsl.dhis2.cucumber;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/CommonUtils/Dhis2Verifier/src/main/java/org/rtsl/dhis2/cucumber/Dhis2IdConverter.java
+++ b/CommonUtils/Dhis2Verifier/src/main/java/org/rtsl/dhis2/cucumber/Dhis2IdConverter.java
@@ -1,4 +1,4 @@
-package org.rtsl.dhis2.cucumber.utils;
+package org.rtsl.dhis2.cucumber;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/CommonUtils/Dhis2Verifier/src/main/java/org/rtsl/dhis2/cucumber/Helper.java
+++ b/CommonUtils/Dhis2Verifier/src/main/java/org/rtsl/dhis2/cucumber/Helper.java
@@ -1,4 +1,4 @@
-package org.rtsl.dhis2.cucumber.utils;
+package org.rtsl.dhis2.cucumber;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/CommonUtils/Dhis2Verifier/src/main/java/org/rtsl/dhis2/cucumber/Period.java
+++ b/CommonUtils/Dhis2Verifier/src/main/java/org/rtsl/dhis2/cucumber/Period.java
@@ -1,4 +1,4 @@
-package org.rtsl.dhis2.cucumber.utils;
+package org.rtsl.dhis2.cucumber;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;

--- a/CommonUtils/Dhis2Verifier/src/main/java/org/rtsl/dhis2/cucumber/TestUniqueId.java
+++ b/CommonUtils/Dhis2Verifier/src/main/java/org/rtsl/dhis2/cucumber/TestUniqueId.java
@@ -1,4 +1,4 @@
-package org.rtsl.dhis2.cucumber.utils;
+package org.rtsl.dhis2.cucumber;
 
 public final class TestUniqueId {
 

--- a/CommonUtils/Dhis2Verifier/src/main/java/org/rtsl/dhis2/cucumber/definitions/Dhis2StepDefinitions.java
+++ b/CommonUtils/Dhis2Verifier/src/main/java/org/rtsl/dhis2/cucumber/definitions/Dhis2StepDefinitions.java
@@ -1,7 +1,7 @@
 package org.rtsl.dhis2.cucumber.definitions;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.rtsl.dhis2.cucumber.utils.Helper.toISODateTimeString;
+import static org.rtsl.dhis2.cucumber.Helper.toISODateTimeString;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -9,11 +9,11 @@ import java.util.List;
 import java.util.Map;
 
 import org.hisp.dhis.api.model.v40_2_2.AttributeInfo;
-import org.rtsl.dhis2.cucumber.utils.Dhis2HttpClient;
-import org.rtsl.dhis2.cucumber.utils.Dhis2IdConverter;
+import org.rtsl.dhis2.cucumber.Dhis2HttpClient;
+import org.rtsl.dhis2.cucumber.Dhis2IdConverter;
 import org.rtsl.dhis2.cucumber.factories.OrganisationUnit;
 import org.rtsl.dhis2.cucumber.factories.TrackedEntityInstance;
-import org.rtsl.dhis2.cucumber.utils.Period;
+import org.rtsl.dhis2.cucumber.Period;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/CommonUtils/Dhis2Verifier/src/main/java/org/rtsl/dhis2/cucumber/factories/OrganisationUnit.java
+++ b/CommonUtils/Dhis2Verifier/src/main/java/org/rtsl/dhis2/cucumber/factories/OrganisationUnit.java
@@ -1,13 +1,13 @@
 package org.rtsl.dhis2.cucumber.factories;
 
-import static org.rtsl.dhis2.cucumber.utils.Helper.toISODateTimeString;
+import static org.rtsl.dhis2.cucumber.Helper.toISODateTimeString;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.rtsl.dhis2.cucumber.utils.Dhis2HttpClient;
-import org.rtsl.dhis2.cucumber.utils.TestUniqueId;
+import org.rtsl.dhis2.cucumber.Dhis2HttpClient;
+import org.rtsl.dhis2.cucumber.TestUniqueId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/CommonUtils/Dhis2Verifier/src/main/java/org/rtsl/dhis2/cucumber/factories/TrackedEntityInstance.java
+++ b/CommonUtils/Dhis2Verifier/src/main/java/org/rtsl/dhis2/cucumber/factories/TrackedEntityInstance.java
@@ -2,15 +2,15 @@ package org.rtsl.dhis2.cucumber.factories;
 
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
-import org.rtsl.dhis2.cucumber.utils.Dhis2HttpClient;
-import org.rtsl.dhis2.cucumber.utils.Dhis2IdConverter;
+import org.rtsl.dhis2.cucumber.Dhis2HttpClient;
+import org.rtsl.dhis2.cucumber.Dhis2IdConverter;
 import org.rtsl.dhis2.cucumber.definitions.Dhis2StepDefinitions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 
-import static org.rtsl.dhis2.cucumber.utils.Helper.toISODateTimeString;
+import static org.rtsl.dhis2.cucumber.Helper.toISODateTimeString;
 
 public class TrackedEntityInstance {
 

--- a/CommonUtils/Dhis2Verifier/src/main/resources/spring.main.xml
+++ b/CommonUtils/Dhis2Verifier/src/main/resources/spring.main.xml
@@ -45,7 +45,7 @@
         </property>
     </bean>
 
-    <bean id="testUniqueId" class="org.rtsl.dhis2.cucumber.utils.TestUniqueId" scope="cucumber-glue"/>      
+    <bean id="testUniqueId" class="org.rtsl.dhis2.cucumber.TestUniqueId" scope="cucumber-glue"/>      
     <bean id="organisationUnit" class="org.rtsl.dhis2.cucumber.factories.OrganisationUnit" scope="cucumber-glue">
         <constructor-arg value="${dhis2.orgUnit.level1Name}"/>
         <constructor-arg value="${dhis2.orgUnit.level2NamePrefix}"/>
@@ -70,12 +70,12 @@
         <constructor-arg value="${dhis2.api.password}" />
     </bean>
     <bean id="dhisSdkClient" factory-bean="dhis2SdkClientBuilder" factory-method="build" />
-    <bean id="testClient" class="org.rtsl.dhis2.cucumber.utils.Dhis2HttpClient" scope="singleton">
+    <bean id="testClient" class="org.rtsl.dhis2.cucumber.Dhis2HttpClient" scope="singleton">
         <constructor-arg value="${dhis2.api.url}" />
         <constructor-arg value="${dhis2.api.username}" />
         <constructor-arg value="${dhis2.api.password}" />
     </bean>
-    <bean id="testIdConverter" class="org.rtsl.dhis2.cucumber.utils.Dhis2IdConverter" init-method="getMetadata" scope="singleton">
+    <bean id="testIdConverter" class="org.rtsl.dhis2.cucumber.Dhis2IdConverter" init-method="getMetadata" scope="singleton">
         <constructor-arg ref="testClient" />
     </bean>
 </beans>

--- a/CommonUtils/Dhis2Verifier/src/test/java/org/rtsl/dhis2/cucumber/HelperTests.java
+++ b/CommonUtils/Dhis2Verifier/src/test/java/org/rtsl/dhis2/cucumber/HelperTests.java
@@ -1,4 +1,4 @@
-package org.rtsl.dhis2.cucumber.utils;
+package org.rtsl.dhis2.cucumber;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;

--- a/CommonUtils/Dhis2Verifier/src/test/java/org/rtsl/dhis2/cucumber/PeriodTests.java
+++ b/CommonUtils/Dhis2Verifier/src/test/java/org/rtsl/dhis2/cucumber/PeriodTests.java
@@ -1,4 +1,4 @@
-package org.rtsl.dhis2.cucumber.utils;
+package org.rtsl.dhis2.cucumber;
 
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;


### PR DESCRIPTION
Some packages were referencing a path which did not exist in the file structure. This caused the Dhis2Verifier — although it builds — to not run.

This change corrects the package path for the affected classes; and Spring
